### PR TITLE
Vnc

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -2,12 +2,11 @@ name: napari
 channels:
   - conda-forge
   - ome
-  - manics
 dependencies:
   - zeroc-ice36-python
   - omero-py
   - pip
-  - websockify=0.9.0
+  - websockify
   # https://github.com/napari/napari/blob/v0.2.10/requirements/default.txt
   - dask
   - fsspec
@@ -25,10 +24,8 @@ dependencies:
   - pyside2
   - wrapt
   - numpydoc
+  - jupyter-server-proxy
   - pip:
-    # Recent jupyter-server-proxy to load vnc_lite.html instead of /
-    # https://github.com/jupyterhub/jupyter-server-proxy/pull/151
-    - https://github.com/jupyterhub/jupyter-server-proxy/archive/0e67e1afd0bab1342443f13bd147a2f8c682e9e0.zip
     # The conda pyside2 package doesn't appear in pip list so napari tries to reinstall it
     # https://github.com/conda-forge/pyside-feedstock/issues/35
     # napari==

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -7,29 +7,38 @@ dependencies:
   - omero-py
   - pip
   - websockify
-  # https://github.com/napari/napari/blob/v0.2.10/requirements/default.txt
+  - jupyter-server-proxy
+  # https://github.com/napari/napari/blob/v0.4.7/setup.cfg
+  - appdirs
+  - cachey
   - dask
-  - fsspec
   - imageio
+  - importlib-metadata
+  - jsonschema
   - ipykernel
+  - magicgui
+  - napari-console
+  - napari-svg
+  - numpydoc
   - numpy
+  - Pillow
+  - psutil
+  - PyOpenGL
+  - PyYAML
+  - pydantic
   - qtpy
   - qtconsole
   - scipy
-  - scikit-image
+  - tifffile
+  - typing_extensions
+  - toolz
   - vispy
-  - ipython
-  - backcall
-  - pyopengl
   - pyside2
   - wrapt
-  - numpydoc
-  - jupyter-server-proxy
   - pip:
     # The conda pyside2 package doesn't appear in pip list so napari tries to reinstall it
     # https://github.com/conda-forge/pyside-feedstock/issues/35
     # napari==
     # Manually install in postBuild instead with --no-dependencies
-    - cachey
     - napari_plugin_engine
     - ome-zarr

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -21,7 +21,7 @@ sed -i.bak \
     noVNC-1.1.0/vnc_lite.html
 
 # Install tigervnc
-curl -sSfL 'https://bintray.com/tigervnc/stable/download_file?file_path=tigervnc-1.9.0.x86_64.tar.gz' | tar -zxf - --strip=2
+curl -sSfL 'https://sourceforge.net/projects/tigervnc/files/stable/1.9.0/tigervnc-1.9.0.x86_64.tar.gz' | tar -zxf - --strip=2
 
 
 cp $REPO_DIR/jupyter_desktop/share/xstartup .

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -31,7 +31,7 @@ chmod +x xstartup
 # Desktop applications
 # Fiji and OMERO insight
 
-OMERO_INSIGHT_VERSION=5.5.14
+OMERO_INSIGHT_VERSION=5.5.18
 OMERO_INSIGHT_URL_BASE=https://github.com/ome/omero-insight/releases/download/v$OMERO_INSIGHT_VERSION
 
 wget https://downloads.imagej.net/fiji/latest/fiji-nojre.zip


### PR DESCRIPTION
This PR fixes the installation of novnc. The file is no longer available at https://bintray.com/tigervnc/stable/download_file?file_path=tigervnc-1.9.0.x86_64.tar.gz.
This stops working over the weekend

This PR also installed dependencies from conda-forge channel

* Check that the desktop can be started.
* Check a notebook


cc @pwalczysko 